### PR TITLE
Added -U parameter to probide full URI instead of host, port etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Usage
 update.py <all|inc>
 	[-H --mongodb-host, -P --mongodb-port]
 	[-mu --mongodb-user, -mp --mongodb-password]
+		[-mu --mongodb-user, -mp --mongodb-password]
+	[-U --mongodb-uri]
 	[-c --contracts,  -p --products, -o --organizations]
 ```
 
@@ -20,6 +22,11 @@ First argument is the type of update.
 If you have no data in your `MongoDB`, there's no difference between `all` and `inc`.
 
 You can also provide host address and port if your `MongoDB` is not running on `localhost`. And username-password if you `MongoDB` uses authentication.
+
+OR
+
+you can provide full URI instead. It can be necessary when connecting to SaaS MongDB. For example, the URI can be as follows.
+'mongodb://user:pass@host:port/db'
 
 The other arguments are collections to load. If the user provides no additional arguments, all available document types are loaded.
 

--- a/py/update.py
+++ b/py/update.py
@@ -77,6 +77,7 @@ if __name__ == '__main__':
 	parser.add_argument('-P', '--mongodb-port', dest='port', action='store', default=27017, type=int)
 	parser.add_argument('-mu', '--mongodb-user', dest='user', action='store')
 	parser.add_argument('-mp', '--mongodb-password', dest='passwd', action='store')
+	parser.add_argument('-U', '--mongodb-uri', dest='uri', action='store')	
 	
 	# parser.add_argument('-n', '--notifications', dest='collections', action='append_const', const='notifications')
 	parser.add_argument('-c', '--contracts', dest='collections', action='append_const', const='contracts')
@@ -88,7 +89,10 @@ if __name__ == '__main__':
 
 	print ts(), 'Starting {type} update'.format(type=args.type)
 	print ts(), 'Connecting mongodb'
-	client = MongoClient(args.host, args.port)
+	if args.uri:
+	    client = MongoClient(args.uri)
+	else:
+	    client = MongoClient(args.host, args.port)
 
 	db = client.zakupki
 


### PR DESCRIPTION
Added -U parameter to probide full URI instead of host, port etc.
It is necessary when using cloud MongoDB because it's URI can be as follows:
mongodb://user:pass@host:port/db'
Surch URI cannot be generated by original update.py
